### PR TITLE
Fix gcc compiler error

### DIFF
--- a/drivers/spi_flash.c
+++ b/drivers/spi_flash.c
@@ -92,6 +92,7 @@
 #endif
 
 static int raspi_wait_ready(int sleep_ms);
+static inline int raspi_write_enable(void);
 static unsigned int spi_wait_nsec = 0;
 
 


### PR DESCRIPTION
This fixing allows to compile u-boot using current versions of gcc